### PR TITLE
Fix redirect for Android devices. Fixes #14

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -63,6 +63,13 @@ def RequestHandlerClassFactory(address, ssids, rcode):
                 self.send_header('Location', new_path)
                 self.end_headers()
 
+            if '/generate_204' == self.path:
+                self.send_response(301) # redirect
+                new_path = f'http://{self.address}/'
+                print(f'redirecting to {new_path}')
+                self.send_header('Location', new_path)
+                self.end_headers()
+
             # Handle a REST API request to return the device registration code
             if '/regcode' == self.path:
                 self.send_response(200)


### PR DESCRIPTION
This adds a 301 redirect for Android devices when /generate_204 is requested.