### PR TITLE
Lock python-networkmanager to supported version

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,1 +1,1 @@
-python-networkmanager
+python-networkmanager==2.1


### PR DESCRIPTION
Lock python-networkmanager to supported version

An update to python-networkmanager requires all files include the following to work:

```
from dbus.mainloop.glib import DBusGMainLoop
DBusGMainLoop(set_as_default=True)
```

Instead of adding this to all the files, and then having to redo all the thorough testing that has been done, this change locks the pip package to version 2.1 which is what this repo was initially built around. It will ensure stability and prevent users cloning and trying to run the repo receiving errors. 

Resolves: https://github.com/OpenAgricultureFoundation/python-wifi-connect/issues/13